### PR TITLE
reduce size of docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,15 @@
-FROM python:3
+FROM python:3.7-slim
 
 WORKDIR /bot
-RUN pip install pipenv && rm -rf /root/.cache
+
 COPY Pipfile .
-RUN pipenv install --pre && rm -rf /root/.cache
+RUN pip install pipenv && \
+    pipenv install --pre && \ 
+    pipenv install --deploy --system && \
+    rm -r /root/.cache/* && \
+    rm -r /root/.local/*
 
 COPY bot.py *.json *.pickle /bot/
 COPY modules modules
 
-CMD [ "pipenv", "run", "python", "-u", "./bot.py" ]
+CMD [ "python", "-u", "./bot.py" ]


### PR DESCRIPTION
Using python:3.7-slim as basimage reduces the image size to 416 MB.