### PR TITLE
enable modules per default

### DIFF
--- a/modules/bot.py
+++ b/modules/bot.py
@@ -1,3 +1,4 @@
+import collections
 from datetime import datetime
 
 from modules.common.module import BotModule
@@ -119,8 +120,11 @@ class MatrixModule(BotModule):
 
     async def show_modules(self, bot, room):
         await bot.send_text(room, "Modules:\n")
-        for modulename, module in bot.modules.items():
-            await bot.send_text(room, f"Name: {modulename:20s} Enabled: {module.enabled}")
+        for modulename, module in collections.OrderedDict(sorted(bot.modules.items())).items():
+            module_message = f"Name: {modulename}\n"\
+                             f"Enabled: {module.enabled} (Can be disabled: {module.can_be_disabled})\n"\
+                             f"Description: {module.help()}\n"
+            await bot.send_text(room, module_message)
 
     def help(self):
         return 'Bot management commands. (quit, version, reload, status, stats, leave, modules, enable, disable)'

--- a/modules/bot.py
+++ b/modules/bot.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+
 from modules.common.module import BotModule
 
 
@@ -6,7 +7,8 @@ class MatrixModule(BotModule):
 
     def __init__(self, name):
         super().__init__(name)
-        self.enable()
+        self.starttime = None
+        self.can_be_disabled = False
 
     def matrix_start(self, bot):
         super().matrix_start(bot)
@@ -15,6 +17,7 @@ class MatrixModule(BotModule):
     async def matrix_message(self, bot, room, event):
         args = event.body.split()
         if len(args) == 2:
+
             if args[1] == 'quit':
                 await self.quit(bot, room, event)
             elif args[1] == 'version':
@@ -88,6 +91,7 @@ class MatrixModule(BotModule):
     async def enable_module(self, bot, room, event, module_name):
         bot.must_be_admin(room, event)
         print(f"asked to enable {module_name}")
+
         if bot.modules.get(module_name):
             module = bot.modules.get(module_name)
             module.enable()
@@ -100,15 +104,18 @@ class MatrixModule(BotModule):
     async def disable_module(self, bot, room, event, module_name):
         bot.must_be_admin(room, event)
         print(f"asked to disable {module_name}")
+
         if bot.modules.get(module_name):
             module = bot.modules.get(module_name)
-            module.disable()
-            module.matrix_stop(bot)
-            bot.save_settings()
-            await bot.send_text(room, f"module {module_name} disabled")
+            if module.can_be_disabled:
+                module.disable()
+                module.matrix_stop(bot)
+                bot.save_settings()
+                await bot.send_text(room, f"module {module_name} disabled")
+            else:
+                await bot.send_text(room, f"module {module_name} cannot be disabled")
         else:
             await bot.send_text(room, f"module with name {module_name} not found. execute !bot modules for a list of available modules")
-
 
     async def show_modules(self, bot, room):
         await bot.send_text(room, "Modules:\n")

--- a/modules/common/module.py
+++ b/modules/common/module.py
@@ -27,7 +27,8 @@ class BotModule(ABC):
     """
 
     def __init__(self, name):
-        self.enabled = False
+        self.enabled = True
+        self.can_be_disabled = True
         self.name = name
 
     def matrix_start(self, bot):
@@ -80,7 +81,7 @@ class BotModule(ABC):
         :return: a dict object that can be converted to JSON
         :rtype: dict
         """
-        return {'enabled': self.enabled}
+        return {'enabled': self.enabled, 'can_be_disabled': self.can_be_disabled}
 
     def set_settings(self, data):
         """Load these settings. It should be the same JSON you returned in previous get_settings
@@ -88,8 +89,10 @@ class BotModule(ABC):
         :param data: a dict object containing the settings read from the account
         :type data: dict
         """
-        if data.get('enabled'):
+        if data.get('enabled') is not None:
             self.enabled = data['enabled']
+        if data.get('can_be_disabled') is not None:
+            self.can_be_disabled = data['can_be_disabled']
 
     def enable(self):
         self.enabled = True

--- a/modules/help.py
+++ b/modules/help.py
@@ -3,10 +3,6 @@ from modules.common.module import BotModule
 
 class MatrixModule(BotModule):
 
-    def __init__(self, name):
-        super().__init__(name)
-        self.enable()
-
     async def matrix_message(self, bot, room, event):
         msg = f'This is Hemppa {bot.version}, a generic Matrix bot. Known commands:\n\n'
 


### PR DESCRIPTION
Enables all modules per default. The bot module cannot be disabled.
Modules can be configured not beeing disableable by setting the attribute `self.can_be_disabled=False`.

The module output is sorted by key now. Added the description and if the module can be disabled.
