### PR TITLE
Added whitelisting feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,8 @@ You can get access token by logging in with Riot and looking from Settings / Hel
 Some commands require sender to be bot owner.
 Typically set your own id into it.
 
+`OWNERS_ONLY` is an optional variable once defined only the owners can operate the bot (this is a form of whitelisting)
+
 __*ATTENTION:*__ Don't include bot itself in `BOT_OWNERS` if cron or any other module that can cause bot to send custom commands is used, as it could potentially be used to run owner commands as the bot itself.
 
 To enable debugging for the root logger set `DEBUG=True`.

--- a/bot.py
+++ b/bot.py
@@ -162,6 +162,11 @@ class Bot:
         if not self.starts_with_command(body):
             return
 
+        if self.owners_only and not self.is_owner(event):
+            self.logger.info(f"Ignoring {event.sender}, because they're not an owner")
+            await self.send_text(room, "Sorry, only bot owner can run commands.")
+            return
+
         # HACK to ignore messages for some time after joining.
         if self.jointime:
             if (datetime.datetime.now() - self.jointime).seconds < self.join_hack_time:
@@ -293,12 +298,14 @@ class Bot:
         bot_owners = os.getenv('BOT_OWNERS')
         access_token = os.getenv('MATRIX_ACCESS_TOKEN')
         join_on_invite = os.getenv('JOIN_ON_INVITE')
+        owners_only = os.getenv('OWNERS_ONLY') is not None
 
         if matrix_server and self.matrix_user and bot_owners and access_token:
             self.client = AsyncClient(matrix_server, self.matrix_user)
             self.client.access_token = access_token
             self.join_on_invite = join_on_invite is not None
             self.owners = bot_owners.split(',')
+            self.owners_only = owners_only
             self.get_modules()
 
         else:


### PR DESCRIPTION
Adding an optional OWNERS_ONLY environment variable will make the bot only usable to the owners list.
 - A little note: It's programmed that OWNERS_ONLY must exist rather than in-taking a Boolean to determine True or False of the OWNERS_ONLY feature (see [diff](https://github.com/vranki/hemppa/pull/62/commits/4d4309531e3a115faf2c6e2dc5325ae38e79b3b0#diff-f289368d1ae6d2d58bec9f799832d932R301))