### PR TITLE
CMD module refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,11 +204,11 @@ Environ variables seen by commands:
 
 Commands:
 
-* !cmd run "command"         - Run command "command" (Must be done as bot owner)
-* !cmd add cmdname "command" - Add new named command "command"  (Must be done as bot owner)
-* !cmd remove cmdname        - Remove named command (Must be done as bot owner)
-* !cmd list                  - List named commands
-* !cmd cmdname               - Run a named command
+* !cmd run command              - Run command "command" (Must be done as bot owner)
+* !cmd add "cmdname" command    - Add new named command "command"  (Must be done as bot owner)
+* !cmd remove "cmdname"         - Remove named command (Must be done as bot owner)
+* !cmd list                     - List named commands
+* !cmd "cmdname"                - Run a named command
 
 Example:
 

--- a/modules/cmd.py
+++ b/modules/cmd.py
@@ -4,11 +4,18 @@ import shlex
 
 
 class MatrixModule(BotModule):
-    commands = dict()  # cmd name -> shell command
+    def __init__(self, name):
+        super().__init__(name)
+        self.commands = []
 
     async def matrix_message(self, bot, room, event):
         args = shlex.split(event.body)
         args.pop(0)
+        if len(args) >= 2:
+            # Get full command without using quotation marks
+            command = f"{args[1]}"
+            for part_of_command in args[2:]:
+                command += f" {part_of_command}"
 
         if len(args) == 2:
             if args[0] == 'run':
@@ -17,26 +24,41 @@ class MatrixModule(BotModule):
                 await self.send_output(bot, room, out)
             if args[0] == 'remove':
                 bot.must_be_owner(event)
-                cmdname = args[1]
-                self.commands.pop(cmdname, None)
-                bot.save_settings()
-                await bot.send_text(room, 'Command removed.')
+                command_number = int(args[1])
+                if self.commands[command_number] is not None:
+                    await bot.send_text(room, f'Removed "{self.commands[command_number]}"')
+                    self.commands.pop(command_number)
+                    bot.save_settings()
+                else:
+                    await bot.send_text(room, f'Could not find command #{command_number}')
         elif len(args) == 3:
             if args[0] == 'add':
                 bot.must_be_owner(event)
-                cmdname = args[1]
-                self.commands[cmdname] = args[2]
+                self.commands.append(command)
                 bot.save_settings()
                 await bot.send_text(room, 'Command added.')
         elif len(args) == 1:
             if args[0] == 'list':
-                await bot.send_text(room, 'Known commands: ' + str(self.commands))
-            elif args[0] in self.commands:
-                self.logger.debug(f"room: {room.display_name} sender: {event.sender} wants to run cmd {args[0]}")
-                out = self.run_command(self.commands[args[0]], event.sender, room.display_name)
-                await self.send_output(bot, room, out)
+                if len(self.commands) == 0:
+                    await bot.send_text(room, "No known commands")
+                else:
+                    list_commands = ""
+                    i = 0
+                    for command_name in self.commands:
+                        list_commands += f"\n - {i}. \"{command_name}\""
+                        i += 1
+                    await bot.send_text(room, 'Known commands: ' + list_commands)
             else:
-                await bot.send_text(room, 'Unknown command.')
+                command_number = int(args[0])
+                target_command = self.commands[command_number]
+                if target_command is not None:
+                    self.logger.debug(
+                        f"room: {room.display_name} sender: {event.sender} wants to run cmd {target_command}"
+                    )
+                    out = self.run_command(target_command, event.sender, room.display_name)
+                    await self.send_output(bot, room, out)
+                else:
+                    await bot.send_text(room, 'Unknown command.')
 
     def help(self):
         return 'Runs shell commands'

--- a/modules/cmd.py
+++ b/modules/cmd.py
@@ -6,59 +6,62 @@ import shlex
 class MatrixModule(BotModule):
     def __init__(self, name):
         super().__init__(name)
-        self.commands = []
+        self.commands = {}
 
     async def matrix_message(self, bot, room, event):
         args = shlex.split(event.body)
         args.pop(0)
-        if len(args) >= 2:
-            # Get full command without using quotation marks
-            command = f"{args[1]}"
-            for part_of_command in args[2:]:
-                command += f" {part_of_command}"
-
-        if len(args) == 2:
-            if args[0] == 'run':
-                bot.must_be_owner(event)
-                out = self.run_command(args[1], event.sender, room.display_name)
-                await self.send_output(bot, room, out)
-            if args[0] == 'remove':
-                bot.must_be_owner(event)
-                command_number = int(args[1])
-                if self.commands[command_number] is not None:
-                    await bot.send_text(room, f'Removed "{self.commands[command_number]}"')
-                    self.commands.pop(command_number)
-                    bot.save_settings()
-                else:
-                    await bot.send_text(room, f'Could not find command #{command_number}')
-        elif len(args) == 3:
-            if args[0] == 'add':
-                bot.must_be_owner(event)
-                self.commands.append(command)
+        # Message body possibilities:
+        #   ["run", "echo", "Hello", "world"]
+        if args[0] == 'run':
+            command_body = MatrixModule.stitch(args[1:])
+            bot.must_be_owner(event)
+            out = self.run_command(command_body, event.sender, room.display_name)
+            await self.send_output(bot, room, out)
+        # Message body possibilities:
+        #   ["remove", "command_name"]
+        elif args[0] == 'remove':
+            command_name = args[1]
+            bot.must_be_owner(event)
+            if command_name in self.commands:
+                await bot.send_text(room, f'Removed "{self.commands[command_name]}"')
+                del self.commands[command_name]
                 bot.save_settings()
-                await bot.send_text(room, 'Command added.')
-        elif len(args) == 1:
-            if args[0] == 'list':
-                if len(self.commands) == 0:
-                    await bot.send_text(room, "No known commands")
-                else:
-                    list_commands = ""
-                    i = 0
-                    for command_name in self.commands:
-                        list_commands += f"\n - {i}. \"{command_name}\""
-                        i += 1
-                    await bot.send_text(room, 'Known commands: ' + list_commands)
             else:
-                command_number = int(args[0])
-                target_command = self.commands[command_number]
-                if target_command is not None:
-                    self.logger.debug(
-                        f"room: {room.display_name} sender: {event.sender} wants to run cmd {target_command}"
-                    )
-                    out = self.run_command(target_command, event.sender, room.display_name)
-                    await self.send_output(bot, room, out)
-                else:
-                    await bot.send_text(room, 'Unknown command.')
+                await bot.send_text(room, f'Could not find command "{command_name}"')
+        # Message body possibilities:
+        #   ["add", "command_name", "echo", "Hello", "world"]
+        elif args[0] == 'add':
+            command_name = args[1]
+            command_body = MatrixModule.stitch(args[2:])
+            bot.must_be_owner(event)
+            self.commands[command_name] = command_body
+            bot.save_settings()
+            await bot.send_text(room, f'Added "{command_name}" -> "{command_body}".')
+        # Message body possibilities:
+        #   ["list"]
+        elif args[0] == 'list':
+            if len(self.commands) == 0:
+                await bot.send_text(room, "No known commands")
+            else:
+                known_commands = "Known commands:\n"
+                for command_name in self.commands.keys():
+                    command_body = self.commands[command_name]
+                    known_commands += f' - "{command_name}" -> "{command_body}"\n'
+                await bot.send_text(room, known_commands)
+        # Message body possibilities:
+        #   ["command_name"]
+        else:
+            command_name = args[0]
+            if command_name in self.commands:
+                target_command = self.commands[command_name]
+                self.logger.debug(
+                    f"room: {room.display_name} sender: {event.sender} wants to run cmd {target_command}"
+                )
+                out = self.run_command(target_command, event.sender, room.display_name)
+                await self.send_output(bot, room, out)
+            else:
+                await bot.send_text(room, 'Unknown command.')
 
     def help(self):
         return 'Runs shell commands'
@@ -72,6 +75,19 @@ class MatrixModule(BotModule):
         super().set_settings(data)
         if data.get('commands'):
             self.commands = data['commands']
+
+    @staticmethod
+    def stitch(body: list) -> str:
+        """
+        This is used for stitching arguments again
+        Examples:
+            ["echo", "Hello", "world"] -> "echo Hello world"
+        Args:
+            body: str[]
+
+        Returns: str
+        """
+        return " ".join(body)
 
     def run_command(self, command, user, roomname):
         self.logger.info(f"Running command {command}..")


### PR DESCRIPTION
Differences:
 - Shell commands being evaluated no longer need to use quotation marks. This allows users to more conveniently add quotation marks to their command body