### PR TITLE
Add Time Zone Environment Variable and cron time Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Commands:
 * !cron daily [hour] [command] - Run command on start of hour (Must be done as room admin)
 * !cron list - List commands in this room
 * !cron clear - Clear command s in this room (Must be done as room admin)
+* !cron time - Print the current datetime and time zone that the cron command will use (time zone set using the `TZ` environment variable)
 
 Examples:
 
@@ -379,6 +380,7 @@ MATRIX_SERVER=https://matrix.org
 JOIN_ON_INVITE=True
 BOT_OWNERS=@user1:matrix.org,@user2:matrix.org
 DEBUG=False
+TZ=America/New_York
 ```
 
 Note: without quotes!
@@ -405,6 +407,8 @@ Typically set your own id into it.
 __*ATTENTION:*__ Don't include bot itself in `BOT_OWNERS` if cron or any other module that can cause bot to send custom commands is used, as it could potentially be used to run owner commands as the bot itself.
 
 To enable debugging for the root logger set `DEBUG=True`.
+
+`TZ` takes any valid [TZ database name](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) value and sets the bot server to the appropriate zone.
 
 ## Module API
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - JOIN_ON_INVITE
       - BOT_OWNERS
       - DEBUG
+      - TZ
     volumes:
       - ${PWD}/config/:/bot/config
       - ${PWD}/credentials.json:/bot/credentials.json

--- a/modules/cron.py
+++ b/modules/cron.py
@@ -1,4 +1,5 @@
 import shlex
+import os
 from datetime import datetime
 
 from .common.module import BotModule
@@ -30,6 +31,8 @@ class MatrixModule(BotModule):
                 self.daily_commands.pop(room.room_id, None)
                 bot.save_settings()
                 await bot.send_text(room, 'Cleared commands on this room.')
+            elif args[0] == 'time':
+                await bot.send_text(room, '{datetime} {timezone}'.format(datetime=datetime.now(), timezone=os.environ.get('TZ')))
 
     def help(self):
         return ('Runs scheduled commands')


### PR DESCRIPTION
Map `TZ` variable from `.env` and print the current time and time zone on `!cron time` command.