### PR TITLE
Don't enable cmd module by default

### DIFF
--- a/modules/cmd.py
+++ b/modules/cmd.py
@@ -6,6 +6,7 @@ import shlex
 class MatrixModule(BotModule):
     def __init__(self, name):
         super().__init__(name)
+        self.enabled = False
         self.commands = {}
 
     async def matrix_message(self, bot, room, event):


### PR DESCRIPTION
Due to the immense power this module can provide, it shouldn't be enabled per default.