### PR TITLE
Fix timeout definition

### DIFF
--- a/modules/url.py
+++ b/modules/url.py
@@ -71,7 +71,8 @@ class MatrixModule(BotModule):
         for url in urls:
             try:
                 title, description = self.get_content_from_url(url)
-            except Exception:
+            except Exception as e:
+                self.logger.info(f"could not fetch url: {e}")
                 # failed fetching, give up
                 continue
 
@@ -100,7 +101,7 @@ class MatrixModule(BotModule):
         """
         title = None
         description = None
-        timeout = httpx.Timeout(10.0, connect_timeout=2.0, read_timeout=5.0)
+        timeout = httpx.Timeout(10.0, connect=2.0, read=5.0)
         try:
             r = httpx.get(url, timeout=timeout)
         except Exception as e:


### PR DESCRIPTION
From: https://github.com/encode/httpx/blob/master/CHANGELOG.md#0150-september-22nd-2020

> The verbose httpx.Timeout(5.0, connect_timeout=60.0) style had previously been deprecated in favour of httpx.Timeout(5.0, connect=60.0). It is now fully removed.

