### PR TITLE
Allow a module to declare aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ Bot management commands.
 
 Prints help on existing modules.
 
+### Alias
+
+Add or remove aliases for a module.
+
+* !alias add osm loc
+* !alias list
+* !alias remove osm
+
 ### Echo
 
 Simple example module that just echoes what user said.

--- a/README.md
+++ b/README.md
@@ -623,6 +623,21 @@ Set the bot_ignore parameter to True in sender functions to acheive this.
 
 If you write a module that installs a custom message handler, use bot.should_ignore_event(event) to check if event should be ignored.
 
+### Aliasing modules
+
+A module can declare its own _aliases_ with the `add_module_aliases` command.
+You probably want to call it during `matrix_start`:
+
+```python
+class MatrixModule(BotModule):
+
+	def matrix_start(self, bot):
+		super().matrix_start(bot)
+		self.add_module_aliases(bot, ['new_name', 'another_name'])
+```
+
+Then you can call this module with its original name, `!new_name`, or `!another_name`
+
 ## Contributing
 
 If you write a new module, please make a PR if it's something useful for others.

--- a/bot.py
+++ b/bot.py
@@ -40,6 +40,7 @@ class Bot:
         self.client = None
         self.join_on_invite = False
         self.modules = dict()
+        self.module_aliases = dict()
         self.leave_empty_rooms = True
         self.pollcount = 0
         self.poll_task = None
@@ -260,7 +261,8 @@ class Bot:
         # Strip away non-alphanumeric characters, including leading ! for security
         command = re.sub(r'\W+', '', command)
 
-        moduleobject = self.modules.get(command)
+        # Fallback to any declared aliases
+        moduleobject = self.modules.get(command) or self.modules.get(self.module_aliases.get(command))
 
         if moduleobject is not None:
             if moduleobject.enabled:

--- a/modules/alias.py
+++ b/modules/alias.py
@@ -1,0 +1,55 @@
+from modules.common.module import BotModule
+import random
+
+class MatrixModule(BotModule):
+    def __init__(self, name):
+        super().__init__(name)
+        self.aliases = dict()
+
+    def set_settings(self, data):
+        super().set_settings(data)
+        if data.get('aliases'):
+            self.aliases = data['aliases']
+
+    def get_settings(self):
+        data = super().get_settings()
+        data['aliases'] = self.aliases
+        return data
+
+    def matrix_start(self, bot):
+        super().matrix_start(bot)
+        bot.module_aliases.update(self.aliases)
+
+    async def matrix_message(self, bot, room, event):
+
+        args = event.body.split()
+        args.pop(0)
+
+        if len(args) == 3:
+            if args.pop(0) == 'add':
+                bot.must_be_owner(event)
+                self.logger.debug(f"room: {room.name} sender: {event.sender} wants to add an alias")
+
+                bot.module_aliases.update({args[0]: args[1]})
+                self.aliases.update({args[0]: args[1]})
+                bot.save_settings()
+                await bot.send_text(room, f'Aliased !{args[0]} to !{args[1]}')
+
+        elif len(args) == 2:
+            if args.pop(0) in ['rm', 'remove']:
+                bot.must_be_owner(event)
+                self.logger.debug(f"room: {room.name} sender: {event.sender} wants to remove an alias")
+
+                old = bot.module_aliases.pop(args[0])
+                self.aliases.pop(args[0])
+                bot.save_settings()
+                await bot.send_text(room, f'Removed alias !{args[0]}')
+
+        elif len(args) == 1:
+            if args.pop(0) in ['ls', 'list']:
+                self.logger.debug(f"room: {room.name} sender: {event.sender} wants to list aliases")
+                msg = '\n'.join([ f'- {key} => {val}' for key, val in bot.module_aliases.items() ])
+                await bot.send_text(room, 'Aliases:\n' + msg)
+
+    def help(self):
+        return 'Alias a command'

--- a/modules/common/module.py
+++ b/modules/common/module.py
@@ -96,6 +96,26 @@ class BotModule(ABC):
         if data.get('can_be_disabled') is not None:
             self.can_be_disabled = data['can_be_disabled']
 
+    def add_module_aliases(self, bot, args, force=False):
+        """Add a list of aliases for this module.
+
+        :param args: a list of strings by which this module can be called
+        :type args: list
+        :param force: override any existing aliases
+        :type force: bool, optional
+        """
+        for name in args:
+            if bot.modules.get(name):
+                self.logger.info(f"aliases: {name} is already a module!")
+                continue
+            prev = bot.module_aliases.get(name)
+            if prev and not force:
+                self.logger.info(f"aliases: {name} already exists for module {prev}")
+                continue
+            if prev:
+                self.logger.info(f"aliases: {name} from module {prev}")
+            bot.module_aliases[name] = self.name
+
     def enable(self):
         self.enabled = True
 


### PR DESCRIPTION
Use cases:

- A `!quotes` module which takes a name as its first argument can be called by `!name` instead of just `!quotes name` ([example](https://github.com/xPMo/hemppa-bot/blob/a783ad99e1c9c5ccc77f55938f5288ae44f017a7/modules/quote.py#L26))
- A module can provide multiple commands which share the same state ([example](https://github.com/xPMo/hemppa-bot/blob/a783ad99e1c9c5ccc77f55938f5288ae44f017a7/modules/show.py#L21))

Thanks for hemppa!