### PR TITLE
Fall back to video['uuid'] if video['url'] doesn't exist

### DIFF
--- a/modules/pt.py
+++ b/modules/pt.py
@@ -54,7 +54,7 @@ class MatrixModule(BotModule):
             data = p.search(query, count)
             if len(data['data']) > 0:
                 for video in data['data']:
-                    video_url = video["url"] #self.instance_url + 'videos/watch/' + video["uuid"]
+                    video_url = video.get("url") or self.instance_url + 'videos/watch/' + video["uuid"]
                     duration = time.strftime('%H:%M:%S', time.gmtime(video["duration"]))
                     instancedata = video["account"]["host"]
                     html = f'<a href="{video_url}">{video["name"]}</a> {video["description"] or ""} [{duration}] @ {instancedata}'


### PR DESCRIPTION
The PeerTube instance I was testing with did not return url property with videos.