### PR TITLE
Enhancing !help

### DIFF
--- a/modules/alias.py
+++ b/modules/alias.py
@@ -51,5 +51,17 @@ class MatrixModule(BotModule):
                 msg = '\n'.join([ f'- {key} => {val}' for key, val in bot.module_aliases.items() ])
                 await bot.send_text(room, 'Aliases:\n' + msg)
 
+            if args.pop(0) == 'help':
+                await bot.send_text(room, self.long_help(bot=bot, event=event))
+
     def help(self):
-        return 'Alias a command'
+        return 'Manage command aliases'
+
+    def long_help(self, bot=None, event=None, **kwargs):
+        text = self.help() + (
+                '\n- "!alias (list|ls)": list defined aliases'
+                '\n- "!alias help": show this help')
+        if bot and event and bot.is_owner(event):
+            text += ('\n- "!alias (remove|rm) [name]": remove an alias'
+                     '\n- "!alias add [name] [command]": add an alias for [command]')
+        return text

--- a/modules/bot.py
+++ b/modules/bot.py
@@ -174,3 +174,16 @@ class MatrixModule(BotModule):
 
     def help(self):
         return 'Bot management commands. (quit, version, reload, status, stats, leave, modules, enable, disable)'
+
+    def long_help(self, bot=None, event=None, **kwargs):
+        text = self.help() + (
+                '\n- "!bot version": get bot version'
+                '\n- "!bot status": get bot uptime and status'
+                '\n- "!bot stats": get current users, rooms, and homeservers')
+        if bot and event and bot.is_owner(event):
+            text += ('\n- "!bot quit": kill the bot :('
+                     '\n- "!bot reload": reload the bot modules'
+                     '\n- "!bot enable [module]": enable a module'
+                     '\n- "!bot disable [module]": disable a module')
+        return text
+

--- a/modules/common/module.py
+++ b/modules/common/module.py
@@ -75,7 +75,18 @@ class BotModule(ABC):
     @abstractmethod
     def help(self):
         """Return one-liner help text"""
-        pass
+        return 'A cool hemppa module'
+
+    def long_help(self, bot=None, room=None, event=None, args=[]):
+        """Return longer help text
+
+        Used by help module as !help modulename [args ...]
+        bot, room, and event are passed to allow a module
+        to give contextual help
+
+        If not defined, falls back to short help
+        """
+        return self.help()
 
     def get_settings(self):
         """Must return a dict object that can be converted to JSON and sent to server

--- a/modules/help.py
+++ b/modules/help.py
@@ -3,10 +3,49 @@ from modules.common.module import BotModule
 
 class MatrixModule(BotModule):
 
+    def __init__(self, name):
+        super().__init__(name)
+        self.msg_users = False
+
+    def get_settings(self):
+        data = super().get_settings()
+        data['msg_users'] = self.msg_users
+        return data
+
+    def set_settings(self, data):
+        super().set_settings(data)
+        if data.get('msg_users'):
+            self.msg_users = data['msg_users']
+
+    def matrix_start(self, bot):
+        super().matrix_start(bot)
+        self.add_module_aliases(bot, ['sethelp'])
+
     async def matrix_message(self, bot, room, event):
 
-        args = event.body.split()[1:]
-        if len(args) > 0:
+        args = event.body.split()
+        cmd = args.pop(0)
+        if cmd == '!sethelp':
+            bot.must_be_owner(event)
+            if len(args) != 2:
+                await bot.send_text(room, f'{cmd} requires two arguments')
+                return
+            if args[0].lower() in ['msg_users', 'msg-users', 'msg']:
+                if args[1].lower() in ['true', '1', 'yes', 'y']:
+                    self.msg_users = True
+                    await bot.send_text(room, '!help will now message users instead of posting to the room')
+                else:
+                    self.msg_users = False
+                    bot.send_text(room, '!help will now post to the room instead of messaging users')
+                bot.save_settings()
+            else:
+                await bot.send_text(room, f'Not a !help setting: {args[0]}')
+
+
+        if len(args) > 1:
+            if args.pop(0) == '!sethelp':
+                bot.must_be_owner(event)
+
             msg = ''
             modulename = args.pop(0)
             moduleobject = bot.modules.get(modulename)
@@ -28,7 +67,10 @@ class MatrixModule(BotModule):
                     except AttributeError:
                         pass
             msg = msg + "\nMore information at https://github.com/vranki/hemppa"
-        await bot.send_text(room, msg)
+        if self.msg_users:
+            await bot.send_msg(event.sender, f'Chat with {bot.matrix_user}', msg)
+        else:
+            await bot.send_text(room, msg)
 
     def help(self):
         return 'Prints help on commands'

--- a/modules/help.py
+++ b/modules/help.py
@@ -4,16 +4,30 @@ from modules.common.module import BotModule
 class MatrixModule(BotModule):
 
     async def matrix_message(self, bot, room, event):
-        msg = f'This is Hemppa {bot.version}, a generic Matrix bot. Known commands:\n\n'
 
-        for modulename, moduleobject in bot.modules.items():
-            if moduleobject.enabled:
-                msg = msg + '!' + modulename
-                try:
-                    msg = msg + ' - ' + moduleobject.help() + '\n'
-                except AttributeError:
-                    pass
-        msg = msg + "\nMore information at https://github.com/vranki/hemppa"
+        args = event.body.split()[1:]
+        if len(args) > 0:
+            msg = ''
+            modulename = args.pop(0)
+            moduleobject = bot.modules.get(modulename)
+            if not moduleobject.enabled:
+                msg += f'{modulename} is disabled\n'
+            try:
+                msg += moduleobject.long_help(bot=bot, room=room, event=event, args=args)
+            except AttributeError:
+                msg += f'{modulename} has no help'
+
+        else:
+            msg = f'This is Hemppa {bot.version}, a generic Matrix bot. Known commands:\n\n'
+
+            for modulename, moduleobject in bot.modules.items():
+                if moduleobject.enabled:
+                    msg = msg + '!' + modulename
+                    try:
+                        msg = msg + ' - ' + moduleobject.help() + '\n'
+                    except AttributeError:
+                        pass
+            msg = msg + "\nMore information at https://github.com/vranki/hemppa"
         await bot.send_text(room, msg)
 
     def help(self):

--- a/modules/help.py
+++ b/modules/help.py
@@ -43,9 +43,6 @@ class MatrixModule(BotModule):
 
 
         if len(args) > 1:
-            if args.pop(0) == '!sethelp':
-                bot.must_be_owner(event)
-
             msg = ''
             modulename = args.pop(0)
             moduleobject = bot.modules.get(modulename)

--- a/modules/room.py
+++ b/modules/room.py
@@ -20,6 +20,14 @@ class MatrixModule(BotModule):
     def help(self):
         return "Commands for interacting with the current room "
 
+    def long_help(self, **kwargs):
+        return self.help() + (
+                '\n- "!room servers": List all servers in the current room'
+                '\n- "!room joined": Count how many users are in the current room'
+                '\n- "!room banned": List all users banned from the current room and the provided reason'
+                '\n- "!room kicked": List all users kicked from the current room and the provided reason'
+                '\n- "!room state [event_type] [[state_key]]": Get a state event (state_key optional)')
+
     async def matrix_message(self, bot, room, event):
         args = event.body.split()
         args.pop(0)

--- a/modules/wa.py
+++ b/modules/wa.py
@@ -119,3 +119,12 @@ class MatrixModule(BotModule):
 
     def help(self):
         return ('Wolfram Alpha search')
+
+    def long_help(self, bot=None, event=None, **kwargs):
+        text = self.help() + (
+            '\n- "!wa [query]": Query WolframAlpha and return the primary pod'
+            '\n- "!wafull [query]": Query WolframAlpha and return all pods'
+            )
+        if bot and event and bot.is_owner(event):
+            text += '\n- "!wa appid [appid]": Set appid'
+        return text


### PR DESCRIPTION
For #127

- Adds long_help via `!help [cmd]` and `module.long_help(**kwargs)`.
- Adds long_help(**kwargs) for some commands, and for those it only shows the subcommands that the event.sender can run.
- Adds `!sethelp msg true` to reply to !help requests with a dm instead of to the room. 

Needs review, I don't know how idiomatic the current `**kwargs` implementation is, or the way I am building strings is. My rationale for using kwargs is if a user wanted to write a long_help() which just returns a static string, they can just write it as `long_help(self, **kwargs): return 'string'` and not have to worry about the optional arguments passed to it.