### PR TITLE
Lock in send_entry and safe unpack on pms.get_image

### DIFF
--- a/modules/tautulli.py
+++ b/modules/tautulli.py
@@ -47,8 +47,8 @@ async def send_entry(bot, room, entry):
                 if not pms_image:
                     return
 
-                (image0, image1) = pms_image
-                matrix_uri = await bot.upload_and_send_image(room, image0, "", True, image1)
+                (blob, content_type) = pms_image
+                matrix_uri = await bot.upload_and_send_image(room, blob, "", True, content_type)
 
                 if matrix_uri is not None:
                     await bot.send_image(room, matrix_uri, "")

--- a/modules/tautulli.py
+++ b/modules/tautulli.py
@@ -102,25 +102,27 @@ class WebServer:
         loop.run_until_complete(site.start())
 
     async def notify(self, request: web.Request) -> web.Response:
+        if not request:
+            return web.Response()
+
         try:
-            if request:
-                data = await request.json()
-                if "genres" in data:
-                    data["genres"] = data["genres"].split(",")
+            data = await request.json()
+            if "genres" in data:
+                data["genres"] = data["genres"].split(",")
 
-                if "actors" in data:
-                    data["actors"] = data["actors"].split(",")
+            if "actors" in data:
+                data["actors"] = data["actors"].split(",")
 
-                if "directors" in data:
-                    data["directors"] = data["directors"].split(",")
+            if "directors" in data:
+                data["directors"] = data["directors"].split(",")
 
-                for room_id in self.rooms:
-                    room = MatrixRoom(room_id=room_id, own_user_id=os.getenv("BOT_OWNERS"), encrypted=self.rooms[room_id])
-                    await send_entry(self.bot, room, data)
+            for room_id in self.rooms:
+                room = MatrixRoom(room_id=room_id, own_user_id=os.getenv("BOT_OWNERS"), encrypted=self.rooms[room_id])
+                await send_entry(self.bot, room, data)
 
-            except Exception as exc:
-                message = str(exc)
-                return web.HTTPBadRequest(body=message)
+        except Exception as exc:
+            message = str(exc)
+            return web.HTTPBadRequest(body=message)
 
         return web.Response()
 

--- a/modules/tautulli.py
+++ b/modules/tautulli.py
@@ -44,6 +44,9 @@ async def send_entry(bot, room, entry):
             if plexpy:
                 pms = plexpy.pmsconnect.PmsConnect()
                 (image0, image1) = pms.get_image(entry["art"], 600, 300)
+                if not image0 or image1:
+                    return
+
                 matrix_uri = await bot.upload_and_send_image(room, image0, "", True, image1)
 
                 if matrix_uri is not None:
@@ -102,9 +105,6 @@ class WebServer:
         loop.run_until_complete(site.start())
 
     async def notify(self, request: web.Request) -> web.Response:
-        if not request:
-            return web.Response()
-
         try:
             data = await request.json()
             if "genres" in data:

--- a/modules/tautulli.py
+++ b/modules/tautulli.py
@@ -43,10 +43,11 @@ async def send_entry(bot, room, entry):
             global plexpy
             if plexpy:
                 pms = plexpy.pmsconnect.PmsConnect()
-                (image0, image1) = pms.get_image(entry["art"], 600, 300)
-                if not image0 or image1:
+                pms_image = pms.get_image(entry["art"], 600, 300)
+                if not pms_image:
                     return
 
+                (image0, image1) = pms_image
                 matrix_uri = await bot.upload_and_send_image(room, image0, "", True, image1)
 
                 if matrix_uri is not None:

--- a/modules/tautulli.py
+++ b/modules/tautulli.py
@@ -34,32 +34,35 @@ def load_tautulli():
         return None
 
 plexpy = load_tautulli()
+send_entry_lock = asyncio.Lock()
 
 async def send_entry(bot, room, entry):
-    if "art" in entry:
-        global plexpy
-        if plexpy:
-            pms = plexpy.pmsconnect.PmsConnect()
-            (image0, image1) = pms.get_image(entry["art"], 600, 300)
-            matrix_uri = await bot.upload_and_send_image(room, image0, "", True, image1)
+    global send_entry_lock
+    async with send_entry_lock:
+        if "art" in entry:
+            global plexpy
+            if plexpy:
+                pms = plexpy.pmsconnect.PmsConnect()
+                (image0, image1) = pms.get_image(entry["art"], 600, 300)
+                matrix_uri = await bot.upload_and_send_image(room, image0, "", True, image1)
 
-            if matrix_uri is not None:
-                await bot.send_image(room, matrix_uri, "")
-    
-    fmt_params = {
-        "title": entry["title"],
-        "year": entry["year"],
-        "audience_rating": entry["audience_rating"],
-        "directors": ", ".join(entry["directors"]),
-        "actors": ", ".join(entry["actors"]),
-        "summary": entry["summary"],
-        "tagline": entry["tagline"],
-        "genres": ", ".join(entry["genres"])
-    }
+                if matrix_uri is not None:
+                    await bot.send_image(room, matrix_uri, "")
 
-    await bot.send_html(room,
-        msg_template_html.format(**fmt_params),
-        msg_template_plain.format(**fmt_params))
+        fmt_params = {
+            "title": entry["title"],
+            "year": entry["year"],
+            "audience_rating": entry["audience_rating"],
+            "directors": ", ".join(entry["directors"]),
+            "actors": ", ".join(entry["actors"]),
+            "summary": entry["summary"],
+            "tagline": entry["tagline"],
+            "genres": ", ".join(entry["genres"])
+        }
+
+        await bot.send_html(room,
+            msg_template_html.format(**fmt_params),
+            msg_template_plain.format(**fmt_params))
 
 msg_template_html = """
     <b>{title} -({year})- Rating: {audience_rating}</b><br>

--- a/modules/tautulli.py
+++ b/modules/tautulli.py
@@ -103,23 +103,24 @@ class WebServer:
 
     async def notify(self, request: web.Request) -> web.Response:
         try:
-            data = await request.json()
-            if "genres" in data:
-                data["genres"] = data["genres"].split(",")
+            if request:
+                data = await request.json()
+                if "genres" in data:
+                    data["genres"] = data["genres"].split(",")
 
-            if "actors" in data:
-                data["actors"] = data["actors"].split(",")
+                if "actors" in data:
+                    data["actors"] = data["actors"].split(",")
 
-            if "directors" in data:
-                data["directors"] = data["directors"].split(",")
+                if "directors" in data:
+                    data["directors"] = data["directors"].split(",")
 
-            for room_id in self.rooms:
-                room = MatrixRoom(room_id=room_id, own_user_id=os.getenv("BOT_OWNERS"), encrypted=self.rooms[room_id])
-                await send_entry(self.bot, room, data)
+                for room_id in self.rooms:
+                    room = MatrixRoom(room_id=room_id, own_user_id=os.getenv("BOT_OWNERS"), encrypted=self.rooms[room_id])
+                    await send_entry(self.bot, room, data)
 
-        except Exception as exc:
-            message = str(exc)
-            return web.HTTPBadRequest(body=message)
+            except Exception as exc:
+                message = str(exc)
+                return web.HTTPBadRequest(body=message)
 
         return web.Response()
 


### PR DESCRIPTION
- Lock on send_entry added to enforce that image and text for a single notification are sent atomically
- pms.get_image() can return `NoneType` object, check on it before unpacking (also better variables naming)
