### PR TITLE
Print recent logs with !bot logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Bot management commands.
 * !bot import [module] [json object] - Update a module's settings from json (Must be done as bot owner)
 * !bot import [module] [key ...] [json object] - Update a sub-object in a module from json (Must be done as bot owner)
   * Example: !bot import alias aliases {"osm": "loc", "sh": "cmd"}
-* !bot logs [module] - Print the most recent messages the given module has reported (Must be done as bot owner)
+* !bot logs [module] ([count]) - Print the [count] most recent messages the given module has reported (Must be done as bot owner)
 * !bot stats - show statistics on matrix users seen by bot
 * !bot leave - ask bot to leave this room (Must be done as admin in room)
 * !bot modules - list all modules including enabled status

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Bot management commands.
 * !bot import [module] [json object] - Update a module's settings from json (Must be done as bot owner)
 * !bot import [module] [key ...] [json object] - Update a sub-object in a module from json (Must be done as bot owner)
   * Example: !bot import alias aliases {"osm": "loc", "sh": "cmd"}
+* !bot logs [module] - Print the most recent messages the given module has reported (Must be done as bot owner)
 * !bot stats - show statistics on matrix users seen by bot
 * !bot leave - ask bot to leave this room (Must be done as admin in room)
 * !bot modules - list all modules including enabled status

--- a/bot.py
+++ b/bot.py
@@ -236,7 +236,16 @@ class Bot:
         :return bool: Success upon sending the message
         """
         # Sends private message to user. Returns true on success.
+        msg_room = await self.find_or_create_private_msg(mxid, roomname)
+        if not msg_room or (type(msg_room) is RoomCreateError):
+            self.logger.error(f'Unable to create room when trying to message {mxid}')
+            return False
 
+        # Send message to the room
+        await self.send_text(msg_room, message)
+        return True
+
+    async def find_or_create_private_msg(self, mxid, roomname):
         # Find if we already have a common room with user:
         msg_room = None
         for croomid in self.client.rooms:
@@ -253,15 +262,9 @@ class Bot:
                 is_direct=True,
                 preset=RoomPreset.private_chat,
                 invite={mxid},
-                )
+            )
+        return msg_room
 
-        if not msg_room or (type(msg_room) is RoomCreateError):
-            self.logger.error(f'Unable to create room when trying to message {mxid}')
-            return False
-
-        # Send message to the room
-        await self.send_text(msg_room, message)
-        return True
 
     def remove_callback(self, callback):
         for cb_object in self.client.event_callbacks:

--- a/bot.py
+++ b/bot.py
@@ -314,7 +314,7 @@ class Bot:
             try:
                 module_settings[modulename] = moduleobject.get_settings()
             except Exception:
-                traceback.print_exc(file=sys.stderr)
+                self.logger.exception(f'unhandled exception {modulename}.get_settings')
         data = {self.appid: self.version, 'module_settings': module_settings}
         self.set_account_data(data)
 
@@ -329,7 +329,7 @@ class Bot:
                     moduleobject.set_settings(
                         data['module_settings'][modulename])
                 except Exception:
-                    traceback.print_exc(file=sys.stderr)
+                    self.logger.exception(f'unhandled exception {modulename}.set_settings')
 
     async def message_cb(self, room, event):
         # Ignore if asked to ignore
@@ -373,7 +373,7 @@ class Bot:
                     await self.send_text(room, f'Sorry, only bot owner can run that command.')
                 except Exception:
                     await self.send_text(room, f'Module {command} experienced difficulty: {sys.exc_info()[0]} - see log for details')
-                    traceback.print_exc(file=sys.stderr)
+                    self.logger.exception(f'unhandled exception in !{command}')
         else:
             self.logger.error(f"Unknown command: {command}")
             # TODO Make this configurable
@@ -415,8 +415,7 @@ class Bot:
             cls = getattr(module, 'MatrixModule')
             return cls(modulename)
         except Exception:
-            self.logger.error(f'Module {modulename} failed to load!')
-            traceback.print_exc(file=sys.stderr)
+            self.logger.exception(f'Module {modulename} failed to load')
             return None
 
     def reload_modules(self):
@@ -446,7 +445,7 @@ class Bot:
                     try:
                         await moduleobject.matrix_poll(self, self.pollcount)
                     except Exception:
-                        traceback.print_exc(file=sys.stderr)
+                        self.logger.exception(f'unhandled exception from {modulename}.matrix_poll')
             await asyncio.sleep(10)
 
     def set_account_data(self, data):
@@ -511,7 +510,7 @@ class Bot:
                 try:
                     moduleobject.matrix_start(self)
                 except Exception:
-                    traceback.print_exc(file=sys.stderr)
+                    self.logger.exception(f'unhandled exception from {modulename}.matrix_start')
         self.logger.info(f'All modules started.')
 
     def stop(self):
@@ -520,7 +519,7 @@ class Bot:
             try:
                 moduleobject.matrix_stop(self)
             except Exception:
-                traceback.print_exc(file=sys.stderr)
+                self.logger.exception(f'unhandled exception from {modulename}.matrix_stop')
         self.logger.info(f'All modules stopped.')
 
     async def run(self):


### PR DESCRIPTION
Closes #48 

![2021-05-04_23:59:01 xcI](https://user-images.githubusercontent.com/16061366/117098670-ab747800-ad5e-11eb-8382-86f0dcdc195a.png)

TODO:
- [x] Implement !bot logs
- [x] Replace tracebacks with self.logger.exception()
- [x] Add filters to !bot logs, i.e.: `!bot logs apod` to get the most recent apod logs.
- [x] Add README info.

Possible additions, I'm not considering these right now:
- [ ] Allow !bot logger to only track a certain threshold of logs
- [ ] Keep more than ten, and print the number requested as in `!bot logs 15`
