### PR TITLE
Change bot.upload_and_send() and !apod

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,20 +35,24 @@ Bot management commands.
 * !bot status - print bot status information
 * !bot ping - print the ping time between the server and the bot
 * !bot version - print version and uptime of the bot
-* !bot quit - quit the bot process (Must be done as bot owner)
-* !bot reload - reload all bot modules  (Must be done as bot owner)
-* !bot export - export all bot settings as json (Must be done as bot owner)
-* !bot export [module] - export a module's settings as json (Must be done as bot owner)
-* !bot import [json object] - Update all bot settings from json (Must be done as bot owner)
-* !bot import [module] [json object] - Update a module's settings from json (Must be done as bot owner)
-* !bot import [module] [key ...] [json object] - Update a sub-object in a module from json (Must be done as bot owner)
-  * Example: !bot import alias aliases {"osm": "loc", "sh": "cmd"}
-* !bot logs [module] ([count]) - Print the [count] most recent messages the given module has reported (Must be done as bot owner)
 * !bot stats - show statistics on matrix users seen by bot
-* !bot leave - ask bot to leave this room (Must be done as admin in room)
+
+The following must be done as the bot owner:
+* !bot enable [module] - enable module
+* !bot disable [module] - disable module
+* !bot quit - quit the bot process
+* !bot reload - reload all bot modules
+* !bot export - export all bot settings as json
+* !bot export [module] - export a module's settings as json
+* !bot import [json object] - Update all bot settings from json
+* !bot import [module] [json object] - Update a module's settings from json
+* !bot import [module] [key ...] [json object] - Update a sub-object in a module from json
+  * Example: !bot import alias aliases {"osm": "loc", "sh": "cmd"}
+* !bot logs [module] ([count]) - Print the [count] most recent messages the given module has reported
+* !bot uricache (view|clean|clear) - View the uri cache, or clear it.
+The uri cache prevents the bot from uploading a blob from a url repeatedly
+* !bot leave - ask bot to leave this room
 * !bot modules - list all modules including enabled status
-* !bot enable [module] - enable module (Must be done as admin in room)
-* !bot disable [module] - disable module (Must be done as admin in room)
 
 ### Help
 

--- a/modules/bot.py
+++ b/modules/bot.py
@@ -69,6 +69,8 @@ class MatrixModule(BotModule):
                 await self.import_settings(bot, event)
             elif args[1] == 'logs':
                 await self.last_logs(bot, room, event, args[2])
+            elif args[1] == 'uricache':
+                await self.manage_uri_cache(bot, room, event, args[2])
         else:
             pass
 
@@ -268,6 +270,19 @@ class MatrixModule(BotModule):
         logs = '\n'.join([self.loghandler.format(record) for record in logs])
 
         return await bot.send_html(msg_room, f'<strong>Logs for {key}:</strong>\n<pre><code class="language-txt">{escape(logs)}</code></pre>', f'Logs for {key}:\n' + logs)
+
+    async def manage_uri_cache(self, bot, room, event, action):
+        bot.must_be_owner(event)
+        if action == 'view':
+            self.logger.info(f"{event.sender} wants to see the uri cache")
+            msg = [f'uri cache size: {len(bot.uri_cache)}']
+            for key, val in bot.uri_cache.items():
+                msg.append('- ' + key + ': ' + val[0])
+            return await bot.send_text(room, '\n'.join(msg))
+        if action in ['clean', 'clear']:
+            self.logger.info(f"{event.sender} wants to clear the uri cache")
+            bot.uri_cache = dict()
+            bot.save_settings()
 
     def disable(self):
         raise ModuleCannotBeDisabled

--- a/modules/tautulli.py
+++ b/modules/tautulli.py
@@ -46,10 +46,7 @@ async def send_entry(bot, room, entry):
                 pms_image = pms.get_image(entry["art"], 600, 300)
                 if pms_image:
                     (blob, content_type) = pms_image
-                    matrix_uri = await bot.upload_and_send_image(room, blob, "", True, content_type)
-
-                    if matrix_uri is not None:
-                        await bot.send_image(room, matrix_uri, "")
+                    await bot.upload_and_send_image(room, blob, "", True, content_type)
 
         fmt_params = {
             "title": entry["title"],


### PR DESCRIPTION
!apod was expected upload_and_send to return a uri for it to cache. Instead, have bot.upload handle caching.

- Move matrix_uri_cache idea from apod into global bot, persist on restart
- ~~TODO:~~ add "!bot uricache [ view | clean ]" command

@aspacca please let me know if this breaks any of your modules. I'm fairly certain it won't, but I don't use them myself.