### PR TITLE
!sethelp info and more

### DIFF
--- a/modules/help.py
+++ b/modules/help.py
@@ -57,13 +57,13 @@ class MatrixModule(BotModule):
                 msg += f'{modulename} has no help'
 
         else:
-            msg = f'This is Hemppa {bot.version}, a generic Matrix bot. Known commands:\n\n'
+            msg = f'This is Hemppa {bot.version}, a generic Matrix bot. Known commands:\n'
 
             for modulename, moduleobject in bot.modules.items():
                 if moduleobject.enabled:
-                    msg = msg + '!' + modulename
+                    msg = msg + '- !' + modulename
                     try:
-                        msg = msg + ' - ' + moduleobject.help() + '\n'
+                        msg = msg + ': ' + moduleobject.help() + '\n'
                     except AttributeError:
                         pass
             msg = msg + '\n' + self.info


### PR DESCRIPTION
This PR allows customizing the info line at the end of `!help` with `!sethelp info [TEXT]`.

Example:

```
!sethelp info More information at https://github.com/vranki/hemppa. Leave your feedback at #hemppa:hacklab.fi.
```
```
This is Hemppa 1.5, a generic Matrix bot. Known commands:
- !cron: Runs scheduled commands
- !echo: Echoes back what user has said
<...>
- !help: Prints help on commands
More information at https://github.com/vranki/hemppa. Leave your feedback at #hemppa:hacklab.fi.
```