### PR TITLE
Bugfix: filesize required for AsyncClient upload

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -126,10 +126,10 @@ class Bot:
         self.client: AsyncClient
         response: UploadResponse
         if blob:
-            (response, alist) = await self.client.upload(lambda a, b: url_or_bytes, blob_content_type)
             i = Image.open(BytesIO(url_or_bytes))
             image_length = len(url_or_bytes)
             content_type = blob_content_type
+            (response, alist) = await self.client.upload(lambda a, b: url_or_bytes, blob_content_type, filesize=image_length)
         else:
             self.logger.debug(f"start downloading image from url {url_or_bytes}")
             headers = {'User-Agent': 'Mozilla/5.0'}


### PR DESCRIPTION
When uploading a blob, upload fails due to filesize= being a required parameter. This fixes the issue.

Discovered when attempting bot.upload_and_send_image(room, binary_content, text, True)