### PR TITLE
apod - fix broken image metadata and error response / logging on room…

### DIFF
--- a/modules/apod.py
+++ b/modules/apod.py
@@ -107,10 +107,10 @@ class MatrixModule(BotModule):
                 matrix_uri, mimetype, w, h, size = await bot.upload_image(apod.hdurl)
             except (UploadFailed, TypeError, ValueError):
                 await bot.send_text(room, f"Something went wrong uploading {apod.hdurl}.")
-        await bot.send_image(room, matrix_uri, apod.hdurl, mimetype, w, h, size)
+        await bot.send_image(room, matrix_uri, apod.hdurl, None, mimetype, w, h, size)
         await bot.send_text(room, f"{apod.explanation}")
         if matrix_uri and set_room_avatar:
-            await bot.set_room_avatar(room, matrix_uri, mimetype, w, h, size)
+            await bot.set_room_avatar(room, matrix_uri, None, mimetype, w, h, size)
 
     async def send_unknown_mediatype(self, room, bot, apod):
         self.logger.debug(f"unknown media_type: {apod.media_type}. sending raw information")


### PR DESCRIPTION
… avatar event errors

There was a parameter off by one error. Propably introduced with the room_send wrapper.

While testing the avatar feature I noticed that nothing happens if the bot is not at least a moderator in the room. So I decided to send that info to the room and log the error message as a warning.

The explanation was not altered by the apod module. Turns out it was broken that day at the api level. See https://api.nasa.gov/planetary/apod?api_key=DEMO_KEY&hd=true&date=2022-09-13

fixes #216